### PR TITLE
feat: Add Post Like management for all logged in users

### DIFF
--- a/src/actions/allLikedPostsActions.js
+++ b/src/actions/allLikedPostsActions.js
@@ -1,0 +1,8 @@
+const updateAllUserLikedPosts = (updatedAllLikedPosts) => {
+    return {
+        type: "UPDATE_ALL_USER_LIKED_POSTS",
+        payload: updatedAllLikedPosts
+    }
+}
+
+export { updateAllUserLikedPosts }

--- a/src/actions/homeFeedActions.js
+++ b/src/actions/homeFeedActions.js
@@ -6,4 +6,11 @@ const updateHomeFeed = (updatedHomeFeed) =>
     }
 }
 
-export { updateHomeFeed }
+const refreshHomeFeed = () => {
+    return {
+        type: "REFRESH_HOME_FEED",
+        payload: []
+    }
+}
+
+export { updateHomeFeed, refreshHomeFeed}

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,2 +1,3 @@
-export { updateHomeFeed } from "./homeFeedActions"
+export { updateHomeFeed, refreshHomeFeed } from "./homeFeedActions"
 export { updateUserDetails } from "./userDetailsActions"
+export { updateAllUserLikedPosts } from "./allLikedPostsActions"

--- a/src/assets/react-icons.js
+++ b/src/assets/react-icons.js
@@ -3,7 +3,8 @@ export {
     AiOutlineBell,
     AiOutlineUser,
     AiOutlineFileGif,
-    AiFillLike
+    AiFillLike,
+    AiOutlineLike
 } from "react-icons/ai"
 
 export {
@@ -15,7 +16,8 @@ export {
     BiEnvelope,
     BiImageAdd,
     BiPoll,
-    BiMap
+    BiMap,
+    BiComment
 } from "react-icons/bi"
 
 export {
@@ -25,3 +27,7 @@ export {
 export {
     IoCalendarOutline
 } from "react-icons/io5"
+
+export {
+    RiShareForwardLine
+} from "react-icons/ri"

--- a/src/components/ActiveContacts/ActiveContacts.css
+++ b/src/components/ActiveContacts/ActiveContacts.css
@@ -1,5 +1,6 @@
 .active-connections
 {
+    cursor: pointer;
     padding: 1rem 0;
 }
 
@@ -10,7 +11,6 @@
 
 .active-connections-header-container 
 {
-    cursor: pointer;
     gap: 2rem;
 }
 

--- a/src/components/CreatePost/CreatePost.jsx
+++ b/src/components/CreatePost/CreatePost.jsx
@@ -95,9 +95,9 @@ function CreatePost()
 
                 if(updatedDataResponse.data.status==="ok")
                 {
-                    dispatch(updateHomeFeed(updatedDataResponse.data.homefeed.allHomeFeedPosts))
-                    setNewPostTextContent("")
-                    setPostCharCount(280)
+                  dispatch(updateHomeFeed(updatedDataResponse.data.homefeed))
+                  setNewPostTextContent("")
+                  setPostCharCount(280)
                 }
             }
         }

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -1,14 +1,23 @@
 import React, { useEffect } from 'react'
+import { useDispatch } from "react-redux"
 import { Link } from "react-router-dom"
 import jwt_decode from "jwt-decode";
-import { useUserLogin, useToast } from "../../context/index"
 import { 
     AiOutlineHome,
     AiOutlineBell 
 } from "../../assets/react-icons"
+import { useUserLogin, useToast } from "../../context/index"
+import {
+    refreshHomeFeed
+} from "../../actions/index"
+import {
+    updateAllUserLikedPosts
+} from "../../actions/index"
 import './Navbar.css'
 
 function Navbar() {
+
+    const dispatch = useDispatch()
 
     const { setUserLoggedIn } = useUserLogin(false)
     const { showToast } = useToast()
@@ -33,9 +42,11 @@ function Navbar() {
 
     function logoutUser()
     {
+        dispatch(updateAllUserLikedPosts([]))
         localStorage.removeItem('socioztron-user-token')
         setUserLoggedIn(false)
         localStorage.clear()
+        dispatch(refreshHomeFeed())
         showToast("success","Logged out successfully")
     }
     

--- a/src/components/UserPost/UserPost.css
+++ b/src/components/UserPost/UserPost.css
@@ -117,11 +117,28 @@
 .post-options
 {
     display: flex;
-    padding: 1rem 0;
+    padding: 1rem;
+    gap: 1rem;
 }
 
-.post-options button
+.post-options .post-options-bottom-buttons
 {
-    flex-grow: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    width: calc(100%/3);
+    min-width: fit-content;
+    margin: 0;
+    /* flex-grow: 1; */
 }
 
+.post-options-button-icons
+{
+    font-size: 2rem;
+}
+
+.post-liked
+{
+    color: var(--like-btn-blue)
+}

--- a/src/components/UserPost/UserPost.jsx
+++ b/src/components/UserPost/UserPost.jsx
@@ -1,28 +1,65 @@
+import axios from "axios";
 import { useEffect, useState } from "react"
+import { useNavigate } from "react-router-dom";
+import { useSelector, useDispatch } from "react-redux";
+import jwt_decode from "jwt-decode"
 import {
-    AiFillLike
+    AiFillLike,
+    AiOutlineLike,
+    BiComment,
+    RiShareForwardLine
 } from "../../assets/react-icons"
+import {
+    useUserLogin,
+    useToast
+} from "../../context/index"
+import {
+    updateHomeFeed,
+    updateAllUserLikedPosts
+} from "../../actions/index"
 import './UserPost.css'
 
 function UserPost({userPostDetails})
 {
+    const allUserLikedPosts = useSelector(state => state.allLikedPostsReducer)
+    const { userLoggedIn } = useUserLogin()
+    const { showToast } = useToast()
+    const dispatch = useDispatch()
+    const navigate = useNavigate()
     
     const {
+        _id,
         contentText,
         userName,
         userProfilePic,
         noOfLikes
     } = userPostDetails;
 
-    const [postUserProfile, setPostUserProfile] = useState("https://enztron-dev-branch.netlify.app/Icons-and-Images/Avatars/blue-illustration-avatar.svg")
+    const [ postUserProfile, setPostUserProfile] = useState("https://enztron-dev-branch.netlify.app/Icons-and-Images/Avatars/blue-illustration-avatar.svg")
     const [ showFullText, setShowFullText ] = useState(false)
+    const [ postLikeStatus, setPostLikeStatus ] = useState(false)
 
     useEffect(()=>{
         if(userProfilePic!=="")
         {
             setPostUserProfile(userProfilePic)
         }
-    },[])
+
+        if(userLoggedIn && !postLikeStatus)
+        {
+            let likedPostId = allUserLikedPosts.find(postId => postId==_id )
+            if(likedPostId!=undefined)
+            {
+                setPostLikeStatus(true)
+            } 
+        }  
+        
+        if(!userLoggedIn && postLikeStatus)
+        {
+            setPostLikeStatus(false)
+        }
+    },[allUserLikedPosts,userLoggedIn])
+
 
     let postText1 = "", postText2 = "";
     
@@ -36,6 +73,47 @@ function UserPost({userPostDetails})
     {
         postText1 = postTextArray.slice(0,46).join(" ")
         postText2 = postTextArray.slice(46).join(" ")
+    }
+
+    const handleOptionsHandler = async (callbackPostOptionsFunction) => {
+        const token=localStorage.getItem("socioztron-user-token")
+
+        if(token)
+        {
+            const user = jwt_decode(token)
+                
+            if(!user)
+            {
+                localStorage.removeItem('socioztron-user-token')
+                showToast("warning","Kindly Login")
+                navigate('/login')
+            }
+            else
+            {
+                callbackPostOptionsFunction()
+            }
+        }
+        else
+        {
+            showToast("warning","Kindly Login")
+        }
+    }
+
+    const handlePostLikeStatus = async () => {
+        setPostLikeStatus(prevState => !prevState)
+        let updatedUserAndPostDetails = await axios.patch(
+            `https://socioztron.herokuapp.com/api/userpost/updatelikes/${userPostDetails._id}`,
+            {},
+            {
+                headers: {'x-access-token': localStorage.getItem("socioztron-user-token")}
+            }
+        )
+        
+        if(updatedUserAndPostDetails.data.status==="ok")
+        {
+            dispatch(updateHomeFeed(updatedUserAndPostDetails.data.homefeed))
+            dispatch(updateAllUserLikedPosts(updatedUserAndPostDetails.data.user.likedPosts))
+        }
     }
 
     return (
@@ -52,7 +130,9 @@ function UserPost({userPostDetails})
                     </div>
                     <h3>{userName}</h3>
                 </div>
-                <button className="icon-btn"><i className="fa fa-ellipsis-h fa-x" aria-hidden="true"></i></button>
+                <button className="icon-btn">
+                    <i className="fa fa-ellipsis-h fa-x" aria-hidden="true"></i>
+                </button>
             </div>
             <hr></hr>
             <p className="post-caption">
@@ -88,9 +168,34 @@ function UserPost({userPostDetails})
             </div>
             <hr></hr>
             <div className="post-options">
-                <button className="outline-secondary-btn post-like-button">Like</button>
-                <button className="outline-secondary-btn">Comment</button>
-                <button className="outline-secondary-btn">Share</button>
+                {
+                    postLikeStatus 
+                    ? (
+                        <button 
+                            className="outline-secondary-btn post-options-bottom-buttons post-liked"
+                            onClick={() => handleOptionsHandler(handlePostLikeStatus)}
+                        >
+                            <AiFillLike className="post-options-button-icons"/>
+                            Liked
+                        </button>
+                    ) : (
+                        <button 
+                            className="outline-secondary-btn post-options-bottom-buttons"
+                            onClick={() => handleOptionsHandler(handlePostLikeStatus)}
+                        >
+                            <AiOutlineLike className="post-options-button-icons"/>
+                            Like
+                        </button>
+                    )
+                }
+                <button className="outline-secondary-btn post-options-bottom-buttons">
+                    <BiComment className="post-options-button-icons"/>
+                    Comment
+                </button>
+                <button className="outline-secondary-btn post-options-bottom-buttons">
+                    <RiShareForwardLine className="post-options-button-icons"/>
+                    Share
+                </button>
             </div>
         </div>
     )

--- a/src/pages/Home/Home.css
+++ b/src/pages/Home/Home.css
@@ -45,6 +45,9 @@
 
 .home-suggestion-container
 {
+    position: sticky;
+    top: 12.723rem;
+    align-self: flex-start;
     min-height: fit-content;
     padding: 1rem;
     display: flex;

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -67,7 +67,7 @@ function Home()
                         <hr></hr>
 
                         <WhatsHappeningCard/>
-
+                        
                     </div>
 
                     <div className='active-contacts-container'>

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -2,8 +2,12 @@ import { useEffect } from "react"
 import axios from "axios"
 import { useSelector, useDispatch } from "react-redux"
 import {
-    updateHomeFeed
+    updateHomeFeed,
+    updateAllUserLikedPosts
 } from "../../actions/index"
+import {
+    useUserLogin
+} from "../../context/index"
 import { 
     Sidebar,
     UserPost,
@@ -17,17 +21,28 @@ function Home()
 {
     const homeFeed = useSelector((state)=> state.homeFeedReducer)
     const dispatch = useDispatch()
+    const { userLoggedIn } = useUserLogin()
 
     useEffect(()=>{
         (async ()=>{
-        let updatedHomeFeed = await axios.get(
-            "https://socioztron.herokuapp.com/api/userpost"
-        )
-
-        dispatch(updateHomeFeed(updatedHomeFeed.data.homefeed[0].allHomeFeedPosts))
+            if(userLoggedIn)
+            {
+                let updatedAllUserLikedPosts = await axios.get(
+                    "https://socioztron.herokuapp.com/api/userpost/likedposts",
+                    { 
+                        headers: {'x-access-token': localStorage.getItem("socioztron-user-token")}
+                    }
+                )
+                dispatch(updateAllUserLikedPosts(updatedAllUserLikedPosts.data.likedPosts))
+            }
+     
+            let updatedHomeFeed = await axios.get(
+                "https://socioztron.herokuapp.com/api/userpost"
+            )
+            dispatch(updateHomeFeed(updatedHomeFeed.data.homefeed))
         })()
 
-    },[])
+    },[userLoggedIn])
 
     return (
         <div className='page-container'>

--- a/src/reducers/allLikedPostsReducer.js
+++ b/src/reducers/allLikedPostsReducer.js
@@ -1,0 +1,9 @@
+const allLikedPostsReducer = (state = [], {type, payload}) => {
+    switch(type)
+    {
+        case "UPDATE_ALL_USER_LIKED_POSTS": return [...payload]
+        default: return [...state]
+    }
+}
+
+export { allLikedPostsReducer }

--- a/src/reducers/exploreFeedReducer.js
+++ b/src/reducers/exploreFeedReducer.js
@@ -1,4 +1,3 @@
-
 const exploreFeedReducer = (state = [], { type, payload}) => {
     switch(type)
     {

--- a/src/reducers/homeFeedReducer.js
+++ b/src/reducers/homeFeedReducer.js
@@ -2,6 +2,7 @@ const homeFeedReducer = (state = [], { type, payload}) => {
     switch(type)
     {
         case "UPDATE_HOME_FEED_BY_LATEST" :  return [...(payload.reverse())]
+        case "REFRESH_HOME_FEED"          :  return [...state]
         default : return [...state]
     }
 }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,3 +1,4 @@
 export { homeFeedReducer } from "./homeFeedReducer"
 export { exploreFeedReducer } from "./exploreFeedReducer"
 export { userDetailsReducer } from "./userDetailsReducer"
+export { allLikedPostsReducer } from "./allLikedPostsReducer"

--- a/src/store.js
+++ b/src/store.js
@@ -4,11 +4,12 @@ import promise from "redux-promise-middleware"
 import {
     homeFeedReducer,
     exploreFeedReducer,
-    userDetailsReducer
+    userDetailsReducer,
+    allLikedPostsReducer
 } from "./reducers/index"
 
 export default createStore(
-    combineReducers({homeFeedReducer, exploreFeedReducer, userDetailsReducer}),
+    combineReducers({homeFeedReducer, exploreFeedReducer, userDetailsReducer, allLikedPostsReducer}),
     {},
     applyMiddleware(thunk)
 )


### PR DESCRIPTION
# Added Frontend and Backend for post like management
1. All logged in users can like posts
2. A record of all liked posts by user is maintained in MongoDb using ref
3. Like count is maintained for all posts in the db
4. Button displays as "Like" or "Liked" depending upon if user has not liked post or has already liked post.

# Files to review:
1. UserPost.jsx
2. Home.jsx
3. Majority of changes are on backend so only these 2 files and can ignore Redux files.

# Login Creds to test:
## User 1
Email - newuser1@gmail.com
Password - zxcv

## User 2
Email - newuser2@gmail.com
Password - zxcv